### PR TITLE
Preventative bug fixing on variable scope

### DIFF
--- a/sequence_4/section_9.md
+++ b/sequence_4/section_9.md
@@ -8,16 +8,16 @@ public static final ItemArmor.ArmorMaterial COPPER_ARMOR =
 
 ```java
 //ARMOR
-ItemCopperArmor copperHelmet = new ItemCopperArmor(COPPER_ARMOR, 0, "copper_helmet");
+copperHelmet = new ItemCopperArmor(COPPER_ARMOR, 0, "copper_helmet");
 GameRegistry.registerItem(copperHelmet, MODID + "_" + copperHelmet.getUnlocalizedName());
 
-ItemCopperArmor copperChestplate = new ItemCopperArmor(COPPER_ARMOR, 1, "copper_chestplate");
+copperChestplate = new ItemCopperArmor(COPPER_ARMOR, 1, "copper_chestplate");
 GameRegistry.registerItem(copperChestplate, MODID + "_" + copperChestplate.getUnlocalizedName());
 
-ItemCopperArmor copperLegs = new ItemCopperArmor(COPPER_ARMOR, 2, "copper_legs");
+copperLegs = new ItemCopperArmor(COPPER_ARMOR, 2, "copper_legs");
 GameRegistry.registerItem(copperLegs, MODID + "_" + copperLegs.getUnlocalizedName());
 
-ItemCopperArmor copperBoots = new ItemCopperArmor(COPPER_ARMOR, 3, "copper_boots");
+copperBoots = new ItemCopperArmor(COPPER_ARMOR, 3, "copper_boots");
 GameRegistry.registerItem(copperBoots, MODID + "_" + copperBoots.getUnlocalizedName());
 ```
 


### PR DESCRIPTION
The reason for the removal of `ItemCopperArmor` is to prevent local and class scope conflicts. For example, the `copperBoots` field is accessed from the ItemCopperArmor class for adding the potion effects to the boots. When the students add the `public static ItemCopperArmor copperBoots;` line in the main mod class, the static variable remains a null reference while the local variable is assigned.

Additionally, all Minecraft items and blocks can be accessed globally, so this change will also make it consistent with the Minecraft code base and as taught in previous sections.
