### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/level_2/section_11.md
+++ b/level_2/section_11.md
@@ -4,7 +4,7 @@ A generated structure is a structure that is generated when the world is created
 
 It can be very useful to find these structures, as they can contain useful things like loot chests (which can contain useful items) and monster spawners (for mob farms). 
 
-This section will describe a few structures that could be useful to you. For more information on all structures, check [the wiki](https://minecraft.fandom.com/wiki/Generated_structures) (https://minecraft.fandom.com/wiki/Generated_structures).
+This section will describe a few structures that could be useful to you. For more information on all structures, check [the wiki](https://minecraft.wiki/w/Generated_structures) (https://minecraft.wiki/w/Generated_structures).
 
 ## Aboveground Structures
 

--- a/level_2/section_3.md
+++ b/level_2/section_3.md
@@ -34,7 +34,7 @@ If you keep mining long enough, you're sure to find some good veins of ore!
 
 As you can see from the chart, some ores spawn the most at high Y-coordinates. This is because they generate in mountains. Mining by going to mountain biomes and digging up visible ores can be a safer alternative to underground mining.
 
-Locate a mountain biome by exploring until you see a mountain (remember to bring enough food). You can check your biome by pressing F3. A list of mountain biomes can be found [here](https://minecraft.fandom.com/wiki/Mountains) (https://minecraft.fandom.com/wiki/Mountains).
+Locate a mountain biome by exploring until you see a mountain (remember to bring enough food). You can check your biome by pressing F3. A list of mountain biomes can be found [here](https://minecraft.wiki/w/Mountains) (https://minecraft.wiki/w/Mountains).
 
 <img src="images/section_3/f3_biome.png" style="width:50%">
 

--- a/level_2/section_6.md
+++ b/level_2/section_6.md
@@ -4,7 +4,7 @@
 |:--:|
 | *A desert village* |
 
-Villagers are passive mobs that live in villages (naturally generated groups of buildings). They work at their jobs, breed, and interact with each other. They spawn unemployed, but can be given jobs by placing a job site block near them (there must be a job site block for every employed villager). To learn more about villagers, check out [the wiki](https://minecraft.fandom.com/wiki/Villager) (https://minecraft.fandom.com/wiki/Villager).
+Villagers are passive mobs that live in villages (naturally generated groups of buildings). They work at their jobs, breed, and interact with each other. They spawn unemployed, but can be given jobs by placing a job site block near them (there must be a job site block for every employed villager). To learn more about villagers, check out [the wiki](https://minecraft.wiki/w/Villager) (https://minecraft.wiki/w/Villager).
 
 ## Villager Breeding
 

--- a/level_3/section_10.md
+++ b/level_3/section_10.md
@@ -140,4 +140,4 @@ Now make the `testfor` command only test for your player. You could even make it
 
 * [minecraftcommand.science](https://minecraftcommand.science/) -- "Several minecraft vanilla JSON generators for all your `/give` and `/summon` needs."
 * Minecraft mobspawner and summon generator: [http://minecraft.tools/en/spawn.php](http://minecraft.tools/en/spawn.php)
-* Minecraft wiki command reference: [http://minecraft.gamepedia.com/Commands](http://minecraft.gamepedia.com/Commands)
+* Minecraft wiki command reference: [http://minecraft.wiki/w/Commands](http://minecraft.wiki/w/Commands)

--- a/level_3/section_11.md
+++ b/level_3/section_11.md
@@ -6,11 +6,11 @@ Sorting contraptions involve NOT gates, comparators and exploiting the special c
 
 Here is a screenshot of a basic sorting circuit. The hopper configuration is important here: the bottom row of hoppers must be attached to the chests (shift-click to attach a hopper to a chest) (and to place two chests next to one another, alternate normal chests with trapped chests) and the top row of hoppers must be attached to the comparators (shift-click to attach a hopper to the **side** of the comparator). This is where we exploit a special feature of comparators:
 
-If a comparator is placed next to a container, it will provide an output based on the percentage of used space in the container. see [minecraft.gamepedia.com/Redstone_Comparator](http://minecraft.gamepedia.com/Redstone_Comparator)
+If a comparator is placed next to a container, it will provide an output based on the percentage of used space in the container. see [minecraft.wiki/w/Redstone_Comparator](http://minecraft.wiki/w/Redstone_Comparator)
 
 There is some specific math at the above link to determine how to get the comparator to output, but with the hopper it is easy enough to just fill the hopper until you see the output occur. In this case we're going to fill the hopper so that any additional item creates the redstone signal, which will in turn power the hopper below. This also exploits a special feature of hoppers:
 
-When powered by redstone, the hopper won't take items from the inventories of blocks directly above it, put items into an attached inventory or suck up items from the environment. However, a hopper below it can still take items from its inventory and a hopper above or beside it can still put items into it. see [minecraft.gamepedia.com/Hopper](http://minecraft.gamepedia.com/Hopper)
+When powered by redstone, the hopper won't take items from the inventories of blocks directly above it, put items into an attached inventory or suck up items from the environment. However, a hopper below it can still take items from its inventory and a hopper above or beside it can still put items into it. see [minecraft.wiki/w/Hopper](http://minecraft.wiki/w/Hopper)
 
 Build enough of the circuit to test the output signal from the top hopper. Put a single item of the type you want to sort in the first slot in the hopper. Put a single item that won't be coming through the sorting machine in the rest of slots. Fill the **last** slot until you get a signal, then take one item out. Now only those two items can enter the hopper, and the hopper below will take from the first slot (the item type you want to sort) whenever one more item lands in the topmost hopper.
 

--- a/level_5/section_2.md
+++ b/level_5/section_2.md
@@ -48,7 +48,7 @@ Whenever you create the instance of subclass, an instance of parent class is cre
 
 Therefore, the line `super(Material.ROCK)` is calling the `Block` parent class (in this case, its _constructor_). What can you infer from this line of code?
 
-Answer: this new block is going to inherit some properties of Minecraft [Rock](https://minecraft.gamepedia.com/Rock). 
+Answer: this new block is going to inherit some properties of Minecraft [Rock](https://minecraft.wiki/w/Rock). 
 
 Let's observe this block in the wild. Run the MinecraftByExample project in IntelliJ just as before. Find the block "MBE01 Block Simple" and observe its characteristics. Make sure to observe that when you break the block, it has blue particles, identical to the Lapis particles. It is _inheriting_ those settings from the Lapis block.
 
@@ -142,4 +142,4 @@ Let's update Block Simple's textures. We'll use new cake textures from [here](im
 }
 ```
 
-For more information on block models, see [https://minecraft.gamepedia.com/Model#Block_models](https://minecraft.gamepedia.com/Model#Block_models)
+For more information on block models, see [https://minecraft.wiki/w/Model#Block_models](https://minecraft.wiki/w/Model#Block_models)

--- a/level_5/section_4.md
+++ b/level_5/section_4.md
@@ -63,7 +63,7 @@ You can see the rotation numbers change when in the left hand, and in the GUI th
 
 ![](images/section_4/frog_item.png)
 
-For more information on item models, see [https://minecraft.gamepedia.com/Model#Item_models](https://minecraft.gamepedia.com/Model#Item_models)
+For more information on item models, see [https://minecraft.wiki/w/Model#Item_models](https://minecraft.wiki/w/Model#Item_models)
 
 # Extending an existing item
 
@@ -186,7 +186,7 @@ The key _pattern_ is an array, with each element of the array representing a row
 },
 ```
 
-Hint: Use [https://minecraft.gamepedia.com/Java_Edition_data_values](https://minecraft.gamepedia.com/Java_Edition_data_values) to know what different data values to use, if any are required.
+Hint: Use [https://minecraft.wiki/w/Java_Edition_data_values](https://minecraft.wiki/w/Java_Edition_data_values) to know what different data values to use, if any are required.
 
 Finally, the _result_ key defines what is crafted by this recipe:
 


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.
